### PR TITLE
Pushing snapshot jar on Maven Central only on master push

### DIFF
--- a/.github/workflows/ci-snapshot-release.yml
+++ b/.github/workflows/ci-snapshot-release.yml
@@ -1,7 +1,6 @@
 name: Snapshot Release
 
 on:
-  pull_request:
   push:
     branches:
       - master


### PR DESCRIPTION
Pushing snapshot jar on Maven Central only on master push